### PR TITLE
Update Lambda build path and env vars

### DIFF
--- a/iac/lambda.tf
+++ b/iac/lambda.tf
@@ -2,9 +2,9 @@
  * @application Infrastructure-as-Code (IaC)
  * @source lambda.tf
  * @author Bobwares
- * @version 2.0.0
+ * @version 2.0.1
  * @description Per‑verb Lambda functions.
- * @updated 2025-06-20
+ * @updated 2025-06-21T17:47:19Z
  */
 
 locals {
@@ -25,13 +25,15 @@ module "lambda" {
   function_name      = "${local.domain_title}-${each.key}-${var.environment}"
   runtime            = var.lambda_runtime
   handler            = each.value.handler
-  source_path        = "lambda_function"
+  source_path        = "dist/handlers"
   attach_policy_json = true
   policy_json        = each.value.policy_json
 
   environment_variables = {
     TABLE_NAME    = aws_dynamodb_table.single.name
     DOMAIN_SCHEMA = jsonencode(local.domain_schema)
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED = 1
+    POWERTOOLS_SERVICE_NAME = local.domain_title
   }
 
   tags = merge(var.tags, { Verb = each.key })


### PR DESCRIPTION
# Summary
Adjust Lambda module configuration.

# Details
* **What was added/changed?**
  - Updated `source_path` to point at `dist/handlers`.
  - Added connection reuse and Powertools variables.
  - Bumped lambda.tf header version.
* **Why was it needed?**
  - Aligns Terraform with esbuild output and enables AWS best practices.
* **How was it implemented?**
  - Modified `iac/lambda.tf`.

# Related Tickets
- None

# Checklist
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Linter passes
- [ ] Documentation updated

# Breaking Changes
- None

# Codex Task Link

------
https://chatgpt.com/codex/tasks/task_e_6856ef97d5c0832da0443046a04b4210