### PR TITLE
Add list route and lambda

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,3 +15,12 @@ Update tfvars schema path.
 
 #### Changes
 - Point env schema_path to ../schema/domain.json.
+
+### 0.1.2 – 2025-06-21 18:41:22 UTC (work)
+
+#### Task
+Add GET /items route and Lambda mapping.
+
+#### Changes
+- Add GET /items route in apigw.tf.
+- Register list Lambda in lambda.tf.

--- a/iac/apigw.tf
+++ b/iac/apigw.tf
@@ -2,9 +2,9 @@
  * @application Infrastructure-as-Code (IaC)
  * @source apigw.tf
  * @author Bobwares
- * @version 2.0.0
+ * @version 2.0.1
  * @description HTTP API routes per verb.
- * @updated 2025-06-20
+ * @updated 2025-06-21T18:41:22Z
  */
 
 resource "aws_apigatewayv2_api" "http" {
@@ -24,6 +24,12 @@ resource "aws_apigatewayv2_route" "post" {
   api_id    = aws_apigatewayv2_api.http.id
   route_key = "POST /items"
   target    = "integrations/${aws_apigatewayv2_integration.verb["post"].id}"
+}
+
+resource "aws_apigatewayv2_route" "list" {
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "GET /items"
+  target    = "integrations/${aws_apigatewayv2_integration.verb["list"].id}"
 }
 
 resource "aws_apigatewayv2_route" "get" {

--- a/iac/lambda.tf
+++ b/iac/lambda.tf
@@ -2,14 +2,15 @@
  * @application Infrastructure-as-Code (IaC)
  * @source lambda.tf
  * @author Bobwares
- * @version 2.0.1
+ * @version 2.0.2
  * @description Per‑verb Lambda functions.
- * @updated 2025-06-21T17:47:19Z
+ * @updated 2025-06-21T18:41:22Z
  */
 
 locals {
   lambda_map = {
     post   = { handler = "post/index.handler",  policy_json = data.aws_iam_policy_document.ddb_write.json }
+    list   = { handler = "list/index.handler",  policy_json = data.aws_iam_policy_document.ddb_read.json }
     get    = { handler = "get/index.handler",   policy_json = data.aws_iam_policy_document.ddb_read.json }
     patch  = { handler = "patch/index.handler", policy_json = data.aws_iam_policy_document.ddb_write.json }
     delete = { handler = "delete/index.handler", policy_json = data.aws_iam_policy_document.ddb_delete.json }


### PR DESCRIPTION
# Summary
Add GET /items route and list Lambda configuration.

# Details
* **What was added/changed?**
  - Added GET /items route in `apigw.tf`.
  - Added `list` Lambda entry in `lambda.tf`.
  - Updated changelog to version 0.1.2.
* **Why was it needed?**
  - To allow listing items via API Gateway.
* **How was it implemented?**
  - Extended Terraform API Gateway routes and Lambda map.

# Related Tickets
- None

# Checklist
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Linter passes
- [ ] Documentation updated

# Breaking Changes
None

# Codex Task Link


------
https://chatgpt.com/codex/tasks/task_e_6856fc78cc18832d84c5e51072a8bab5